### PR TITLE
Changed how constant string is declared

### DIFF
--- a/TUPMediaKeyEventMonitor.m
+++ b/TUPMediaKeyEventMonitor.m
@@ -31,7 +31,7 @@
 
 #import "TUPMediaKeyEventMonitor.h"
 
-const static NSString* TUPMediaKeyEventMonitorEnabledKey = @"TUPMediaKeyEventMonitorEnabled";
+static NSString* const TUPMediaKeyEventMonitorEnabledKey = @"TUPMediaKeyEventMonitorEnabled";
 
 @interface TUPMediaKeyEventMonitorThread : NSThread
 - (instancetype)initWithMediaKeyEventHandler:(BOOL (^)(NSEvent*))handler;


### PR DESCRIPTION
This fixes a new warning introduced by Xcode 7.
